### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # HealthFest-Generator
 
-A program created to generate schedules for HealthFest.
+A program created to generate schedules for HealthFest. Can be used to generate schedules for other purposes using the settings file.
 
+[![Run on Repl.it](https://repl.it/badge/github/Nolan-Burkhart/HealthFest-Generator)](https://repl.it/github/Nolan-Burkhart/HealthFest-Generator)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@thenolan/HealthFest-Generator-3).